### PR TITLE
ci: bump GitHub Actions versions (consolidated dependency updates)

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -15,11 +15,11 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
 
@@ -38,7 +38,7 @@ jobs:
           echo "::set-output name=diff::$files"
 
       - name: Comment on PullRequest
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         if: ${{ steps.diff.outputs.diff }}
         with:
           message: |
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.6.0
+        uses: dependabot/fetch-metadata@v2.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,11 +36,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -51,7 +51,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -65,4 +65,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/issue-link-auto-assign.yml
+++ b/.github/workflows/issue-link-auto-assign.yml
@@ -10,7 +10,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Add issue links and assign PR creator to issue
         uses: ./
         with:

--- a/.github/workflows/issue-link-comment.yml
+++ b/.github/workflows/issue-link-comment.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Add issue links with link-style option
         uses: ./
         with:

--- a/.github/workflows/issue-link-noprefix.yml
+++ b/.github/workflows/issue-link-noprefix.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: issue link comment
         uses: ./
         with:

--- a/.github/workflows/issue-link-repo.yml
+++ b/.github/workflows/issue-link-repo.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Add issue links with repository option
         uses: ./
         with:

--- a/.github/workflows/issue-link-top.yml
+++ b/.github/workflows/issue-link-top.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Add issue links to Top
         uses: ./
         with:

--- a/.github/workflows/issue-link.yml
+++ b/.github/workflows/issue-link.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Add issue links
         uses: ./
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
       - name: npm install, build, lint and test


### PR DESCRIPTION
# Implementations
- 溜まっていた Dependabot の GitHub Actions バージョンアップ PR を1本にまとめて取り込みました
  - `actions/checkout` v4 → v5 (#696)
  - `actions/setup-node` v4 → v6 (#715)
  - `github/codeql-action` v3 → v4 (#712)
  - `thollander/actions-comment-pull-request` v2 → v3 (#601)
  - `dependabot/fetch-metadata` v1.6.0 → v2.4.0 (#653)
- 各 workflow ファイル内の `uses:` のタグを差し替えただけで、ジョブの構成・挙動は変更していません

# Review points
- `.github/workflows/*` のみの変更のため release-irrelevant path 扱いとなり changeset は不要です（`changeset-check.yml` のスキップ判定を確認済み）
- ローカルで `npm run check`（lint + tsc + 44 tests）が green であることを確認済みです

# Attentions
- 残っている npm 系の Dependabot PR (#719 `@types/node`, #717 `eslint`, #680 `prettier`, #639 `husky`, #592 `eslint-plugin-jest`) は、`next` に既に取り込まれている #722 (`chore(deps): upgrade dependencies and migrate tooling configs`) によって内容が古くなっています
  - `eslint` (現在 10.8.0)・`prettier` (現在 3.9.6)・`husky` (現在 9.1.7) は PR の提案先バージョンより既に新しく、実質的に不要
  - `eslint-plugin-jest` (#592) はこのプロジェクトから既に削除されており、PR 自体が obsolete
  - `@types/node` (#719, 24.9.2 提案) は現在 20.19.43 のため技術的にはまだ更新余地がありますが、CI の Node ランタイムが `20.x` 固定のため型定義のメジャーバージョンを合わせるかどうかは別途判断が必要と考え、本 PR には含めていません
- 上記の理由により、この PR がマージされたタイミングで #696, #715, #712, #601, #653 の Dependabot PR はクローズしていただいて問題ありません（内容は完全に一致しています）。npm 系の5件は内容が obsolete なため合わせてクローズを検討ください

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkwtxF4oSaaAxRwhzmPyXB)_