### PR TITLE
ci: consolidate release branch onto master, drop next/master split

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "fixed": [],
   "linked": [],
   "access": "restricted",
-  "baseBranch": "master",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "fixed": [],
   "linked": [],
   "access": "restricted",
-  "baseBranch": "next",
+  "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -2,7 +2,7 @@ name: Changeset Check
 
 on:
   pull_request:
-    branches: [next]
+    branches: [master]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -2,7 +2,7 @@ name: Changeset Check
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [next]
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,7 +62,7 @@ jobs:
       # From here on, only run when the release PR was just merged
       # (no unreleased changesets remain) and this version has not been
       # tagged yet. This keeps the job idempotent for unrelated pushes to
-      # `next` and safe to re-run.
+      # `master` and safe to re-run.
       - name: Configure git user
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.meta.outputs.should_release == 'true'
         uses: ./.github/actions/git-bot-identity
@@ -79,7 +79,7 @@ jobs:
           if [[ -n "$(git status --porcelain dist)" ]]; then
             git add dist
             git commit -m 'chore(release): build dist'
-            git push origin HEAD:next
+            git push origin HEAD:master
           else
             echo "dist/ is already up to date, nothing to commit."
           fi
@@ -157,14 +157,3 @@ jobs:
               --title "v${VERSION}" \
               --generate-notes
           fi
-
-      # `master` is a legacy "latest release" pointer branch kept only for
-      # backwards compatibility with existing `@master` consumers. It is not
-      # used for development; every feature PR targets `next`. We force-push
-      # the just-released commit so `@master` always resolves to the latest
-      # release.
-      - name: Sync legacy master branch
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.meta.outputs.should_release == 'true'
-        run: |
-          set -euo pipefail
-          git push --force origin HEAD:master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,26 +63,16 @@ jobs:
       # (no unreleased changesets remain) and this version has not been
       # tagged yet. This keeps the job idempotent for unrelated pushes to
       # `master` and safe to re-run.
+      #
+      # dist/ is not rebuilt here. changesets/action's `version` command
+      # (npm run changeset:version, above) already runs `npm run build` and
+      # commits any diff as part of the release PR itself, so by the time
+      # that PR is merged, HEAD's dist/ is already fresh -- merging a PR
+      # normally satisfies branch protection, so no direct push to `master`
+      # is needed to keep it that way.
       - name: Configure git user
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.meta.outputs.should_release == 'true'
         uses: ./.github/actions/git-bot-identity
-
-      - name: Build
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.meta.outputs.should_release == 'true'
-        run: npm run build
-
-      - name: Commit built dist/
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.meta.outputs.should_release == 'true'
-        run: |
-          set -euo pipefail
-
-          if [[ -n "$(git status --porcelain dist)" ]]; then
-            git add dist
-            git commit -m 'chore(release): build dist'
-            git push origin HEAD:master
-          else
-            echo "dist/ is already up to date, nothing to commit."
-          fi
 
       - name: Create and push release tags
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.meta.outputs.should_release == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,13 +62,13 @@ jobs:
       # From here on, only run when the release PR was just merged
       # (no unreleased changesets remain) and this version has not been
       # tagged yet. This keeps the job idempotent for unrelated pushes to
-      # `master` and safe to re-run.
+      # `main` and safe to re-run.
       #
       # dist/ is not rebuilt here. changesets/action's `version` command
       # (npm run changeset:version, above) already runs `npm run build` and
       # commits any diff as part of the release PR itself, so by the time
       # that PR is merged, HEAD's dist/ is already fresh -- merging a PR
-      # normally satisfies branch protection, so no direct push to `master`
+      # normally satisfies branch protection, so no direct push to `main`
       # is needed to keep it that way.
       - name: Configure git user
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.meta.outputs.should_release == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,15 +47,14 @@ npm run changeset
 ## リリースフロー
 
 1. changeset を含む PR が `master` にマージされます。
-2. `master` への push をトリガーに [changesets/action](https://github.com/changesets/action) が動作し、未リリースの changeset があれば `chore(release): version packages` という Pull Request を自動的に作成・更新します。この PR には `package.json` のバージョン更新、`CHANGELOG.md` の更新、`.changeset/*.md` の削除が含まれます。
+2. `master` への push をトリガーに [changesets/action](https://github.com/changesets/action) が動作し、未リリースの changeset があれば `chore(release): version packages` という Pull Request を自動的に作成・更新します。この PR には `package.json` のバージョン更新、`CHANGELOG.md` の更新、`.changeset/*.md` の削除に加えて、**`npm run build` による `dist/` の再ビルド**が含まれます（`changeset:version` スクリプトが `changeset version && npm run build` を実行するため）。差分が出ればそのまま同じコミットに含まれるので、この PR をマージした時点で `dist/` は常に最新の状態になっています。
 3. この自動生成 PR をレビューし、`master` にマージします。
 4. マージにより再度リリースワークフローが実行され、以下が自動的に行われます。
-   - `npm run build` を実行し、更新された `dist/` を `master` にコミット
    - `vX.Y.Z` タグの作成
    - `vX`・`vX.Y` の移動タグ（moving tag）の更新
    - GitHub Release の作成（`CHANGELOG.md` の該当バージョンのセクションをリリースノートとして使用）
 
-上記のうちステップ 4 は、未リリースの changeset が残っておらず、かつそのバージョンのタグがまだ存在しない場合にのみ実行されます。そのため、無関係な push でリリースが誤って走ることはありません。
+上記のうちステップ 4 は、未リリースの changeset が残っておらず、かつそのバージョンのタグがまだ存在しない場合にのみ実行されます。そのため、無関係な push でリリースが誤って走ることはありません。また、このステップは `master` に対して（タグ以外の）直接 push を一切行わないため、`master` のブランチ保護ルール（PR 経由のみ許可）と衝突しません。
 
 ## メンテナー向けセットアップ
 
@@ -64,4 +63,4 @@ npm run changeset
 - 注意: `GITHUB_TOKEN` によって作成された Pull Request（自動生成される `chore(release): version packages` PR）は、既定では他のワークフローをトリガーしません。そのため `Changeset Check` はこの自動リリース PR 上では実行されず、required status check に設定していると、この PR がいつまでも green にならず自動マージできない状態になります。対処法は次のいずれかです。
   - 管理者権限（admin merge）でこの PR をマージする。
   - リポジトリに `RELEASE_PAT`（`contents: write` / `pull-requests: write` などの権限を持つ Personal Access Token）を Secret として追加する。ワークフローは `secrets.RELEASE_PAT || secrets.GITHUB_TOKEN` を使うようにすでに実装されているため、Secret を追加するだけで自動的に有効になり、ワークフロー側の変更は不要です。
-- リリースジョブは `master` に直接 `dist/` の再ビルドコミットを push します（force-push ではなく通常の fast-forward push）。`master` のブランチ保護ルールが「PR 経由のみ許可」になっていると、この push も拒否されるため、`github-actions`（もしくは `RELEASE_PAT` に紐づくアクター）をブランチ保護の bypass 対象に含めておいてください。
+- リリースジョブは `master` ブランチ自体には（タグ以外）一切 push しないため、`master` のブランチ保護ルールに bypass 設定を追加する必要はありません。`dist/` の鮮度は、リリース PR 作成時に `changeset:version` が実行する `npm run build` によって PR マージ前に担保されています。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 ## ブランチモデル
 
-- 開発のデフォルトブランチは `next` です。機能追加・修正は必ずフィーチャーブランチを切り、`next` へ向けて Pull Request を作成してください。
-- `master` ブランチは「最新リリースを指すポインタ」専用のレガシーブランチです。リリースジョブが自動的に force-push で同期するため、**手動で `master` に push しないでください**。`@master` を参照している既存の利用者との互換性のためだけに維持されています。
+- 開発のデフォルトブランチは `master` です。機能追加・修正は必ずフィーチャーブランチを切り、`master` へ向けて Pull Request を作成してください。
+- `master` はそのまま利用者向けの `@master` 参照先でもあります。タグ付けされていない開発中のコードを含む場合があるため、本番での利用にはタグ（`@v1` や `@v1.9.0` など）の使用を推奨してください。
 
 ## 変更には changeset が必要です
 
@@ -46,23 +46,22 @@ npm run changeset
 
 ## リリースフロー
 
-1. changeset を含む PR が `next` にマージされます。
-2. `next` への push をトリガーに [changesets/action](https://github.com/changesets/action) が動作し、未リリースの changeset があれば `chore(release): version packages` という Pull Request を自動的に作成・更新します。この PR には `package.json` のバージョン更新、`CHANGELOG.md` の更新、`.changeset/*.md` の削除が含まれます。
-3. この自動生成 PR をレビューし、`next` にマージします。
+1. changeset を含む PR が `master` にマージされます。
+2. `master` への push をトリガーに [changesets/action](https://github.com/changesets/action) が動作し、未リリースの changeset があれば `chore(release): version packages` という Pull Request を自動的に作成・更新します。この PR には `package.json` のバージョン更新、`CHANGELOG.md` の更新、`.changeset/*.md` の削除が含まれます。
+3. この自動生成 PR をレビューし、`master` にマージします。
 4. マージにより再度リリースワークフローが実行され、以下が自動的に行われます。
-   - `npm run build` を実行し、更新された `dist/` を `next` にコミット
+   - `npm run build` を実行し、更新された `dist/` を `master` にコミット
    - `vX.Y.Z` タグの作成
    - `vX`・`vX.Y` の移動タグ（moving tag）の更新
    - GitHub Release の作成（`CHANGELOG.md` の該当バージョンのセクションをリリースノートとして使用）
-   - `master` ブランチへの force-push（レガシー利用者向けの同期）
 
 上記のうちステップ 4 は、未リリースの changeset が残っておらず、かつそのバージョンのタグがまだ存在しない場合にのみ実行されます。そのため、無関係な push でリリースが誤って走ることはありません。
 
 ## メンテナー向けセットアップ
 
 - リポジトリに `skip-changeset` ラベルを作成しておいてください（まだ存在しない場合、PR への付与ができません）。
-- `Changeset Check` ワークフローのジョブ名（`Changeset Check`）を `next` ブランチのブランチ保護ルールで required status check に設定できます。
+- `Changeset Check` ワークフローのジョブ名（`Changeset Check`）を `master` ブランチのブランチ保護ルールで required status check に設定できます。
 - 注意: `GITHUB_TOKEN` によって作成された Pull Request（自動生成される `chore(release): version packages` PR）は、既定では他のワークフローをトリガーしません。そのため `Changeset Check` はこの自動リリース PR 上では実行されず、required status check に設定していると、この PR がいつまでも green にならず自動マージできない状態になります。対処法は次のいずれかです。
   - 管理者権限（admin merge）でこの PR をマージする。
   - リポジトリに `RELEASE_PAT`（`contents: write` / `pull-requests: write` などの権限を持つ Personal Access Token）を Secret として追加する。ワークフローは `secrets.RELEASE_PAT || secrets.GITHUB_TOKEN` を使うようにすでに実装されているため、Secret を追加するだけで自動的に有効になり、ワークフロー側の変更は不要です。
-- リリースジョブは最終ステップで `master` ブランチに force-push します。`master` にブランチ保護ルールで force-push を禁止する設定が入っている場合、この同期ステップは失敗します。`github-actions`（もしくは `RELEASE_PAT` に紐づくアクター）による `master` への force-push を許可するか、`master` のブランチ保護ルール自体を外してください。
+- リリースジョブは `master` に直接 `dist/` の再ビルドコミットを push します（force-push ではなく通常の fast-forward push）。`master` のブランチ保護ルールが「PR 経由のみ許可」になっていると、この push も拒否されるため、`github-actions`（もしくは `RELEASE_PAT` に紐づくアクター）をブランチ保護の bypass 対象に含めておいてください。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 ## ブランチモデル
 
-- 開発のデフォルトブランチは `master` です。機能追加・修正は必ずフィーチャーブランチを切り、`master` へ向けて Pull Request を作成してください。
-- `master` はそのまま利用者向けの `@master` 参照先でもあります。タグ付けされていない開発中のコードを含む場合があるため、本番での利用にはタグ（`@v1` や `@v1.9.0` など）の使用を推奨してください。
+- 開発のデフォルトブランチは `main` です。機能追加・修正は必ずフィーチャーブランチを切り、`main` へ向けて Pull Request を作成してください。
+- `master` は既存の `@master` 利用者向けに残しているレガシーブランチで、今後更新されません。本番での利用にはタグ（`@v1` や `@v1.9.0` など）または `@main` の使用を推奨してください。
 
 ## 変更には changeset が必要です
 
@@ -46,21 +46,21 @@ npm run changeset
 
 ## リリースフロー
 
-1. changeset を含む PR が `master` にマージされます。
-2. `master` への push をトリガーに [changesets/action](https://github.com/changesets/action) が動作し、未リリースの changeset があれば `chore(release): version packages` という Pull Request を自動的に作成・更新します。この PR には `package.json` のバージョン更新、`CHANGELOG.md` の更新、`.changeset/*.md` の削除に加えて、**`npm run build` による `dist/` の再ビルド**が含まれます（`changeset:version` スクリプトが `changeset version && npm run build` を実行するため）。差分が出ればそのまま同じコミットに含まれるので、この PR をマージした時点で `dist/` は常に最新の状態になっています。
-3. この自動生成 PR をレビューし、`master` にマージします。
+1. changeset を含む PR が `main` にマージされます。
+2. `main` への push をトリガーに [changesets/action](https://github.com/changesets/action) が動作し、未リリースの changeset があれば `chore(release): version packages` という Pull Request を自動的に作成・更新します。この PR には `package.json` のバージョン更新、`CHANGELOG.md` の更新、`.changeset/*.md` の削除に加えて、**`npm run build` による `dist/` の再ビルド**が含まれます（`changeset:version` スクリプトが `changeset version && npm run build` を実行するため）。差分が出ればそのまま同じコミットに含まれるので、この PR をマージした時点で `dist/` は常に最新の状態になっています。
+3. この自動生成 PR をレビューし、`main` にマージします。
 4. マージにより再度リリースワークフローが実行され、以下が自動的に行われます。
    - `vX.Y.Z` タグの作成
    - `vX`・`vX.Y` の移動タグ（moving tag）の更新
    - GitHub Release の作成（`CHANGELOG.md` の該当バージョンのセクションをリリースノートとして使用）
 
-上記のうちステップ 4 は、未リリースの changeset が残っておらず、かつそのバージョンのタグがまだ存在しない場合にのみ実行されます。そのため、無関係な push でリリースが誤って走ることはありません。また、このステップは `master` に対して（タグ以外の）直接 push を一切行わないため、`master` のブランチ保護ルール（PR 経由のみ許可）と衝突しません。
+上記のうちステップ 4 は、未リリースの changeset が残っておらず、かつそのバージョンのタグがまだ存在しない場合にのみ実行されます。そのため、無関係な push でリリースが誤って走ることはありません。また、このステップは `main` に対して（タグ以外の）直接 push を一切行わないため、`main` のブランチ保護ルール（PR 経由のみ許可）と衝突しません。
 
 ## メンテナー向けセットアップ
 
 - リポジトリに `skip-changeset` ラベルを作成しておいてください（まだ存在しない場合、PR への付与ができません）。
-- `Changeset Check` ワークフローのジョブ名（`Changeset Check`）を `master` ブランチのブランチ保護ルールで required status check に設定できます。
+- `Changeset Check` ワークフローのジョブ名（`Changeset Check`）を `main` ブランチのブランチ保護ルールで required status check に設定できます。
 - 注意: `GITHUB_TOKEN` によって作成された Pull Request（自動生成される `chore(release): version packages` PR）は、既定では他のワークフローをトリガーしません。そのため `Changeset Check` はこの自動リリース PR 上では実行されず、required status check に設定していると、この PR がいつまでも green にならず自動マージできない状態になります。対処法は次のいずれかです。
   - 管理者権限（admin merge）でこの PR をマージする。
   - リポジトリに `RELEASE_PAT`（`contents: write` / `pull-requests: write` などの権限を持つ Personal Access Token）を Secret として追加する。ワークフローは `secrets.RELEASE_PAT || secrets.GITHUB_TOKEN` を使うようにすでに実装されているため、Secret を追加するだけで自動的に有効になり、ワークフロー側の変更は不要です。
-- リリースジョブは `master` ブランチ自体には（タグ以外）一切 push しないため、`master` のブランチ保護ルールに bypass 設定を追加する必要はありません。`dist/` の鮮度は、リリース PR 作成時に `changeset:version` が実行する `npm run build` によって PR マージ前に担保されています。
+- リリースジョブは `main` ブランチ自体には（タグ以外）一切 push しないため、`main` のブランチ保護ルールに bypass 設定を追加する必要はありません。`dist/` の鮮度は、リリース PR 作成時に `changeset:version` が実行する `npm run build` によって PR マージ前に担保されています。

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ jobs:
 
 #### Other examples
 
-- https://github.com/tkt-actions/add-issue-links/tree/master/.github/workflows
+- https://github.com/tkt-actions/add-issue-links/tree/main/.github/workflows
 
 ### Add a section containing a link of related issue to a pull request
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "exec": "run-s build exec:node",
     "exec:node": "node dist/index.js",
     "changeset": "changeset",
-    "changeset:status": "changeset status --since=origin/master",
+    "changeset:status": "changeset status --since=origin/main",
     "changeset:version": "changeset version && npm run build",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "exec": "run-s build exec:node",
     "exec:node": "node dist/index.js",
     "changeset": "changeset",
-    "changeset:status": "changeset status --since=origin/next",
+    "changeset:status": "changeset status --since=origin/master",
     "changeset:version": "changeset version && npm run build",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary
- `master`へのforce-push同期ステップ(`Sync legacy master branch`)が、`master`の「PR経由のみ許可」ブランチ保護ルールと衝突して失敗していた(PR #726マージ後のrelease.yml実行で確認)。
- 原因を辿ると、開発ブランチ`next`とリリースポインタ`master`を分ける構成自体がforce-pushを必要としていたため、両者を一本化する方針とした。
- **`next`は`master`ではなく`main`にリネームする方針に変更。** `master`を先に削除する必要がなく(`main`は現時点で存在しないブランチ名)、`master`はそのまま既存`@master`利用者向けのレガシーブランチとして残せる(今後更新はされない)。
- `release.yml`/`changeset-check.yml`のトリガーブランチ、`.changeset/config.json`の`baseBranch`、`package.json`の`changeset:status`スクリプト、`CONTRIBUTING.md`の説明を`main`に統一し、不要になった`Sync legacy master branch`ステップを削除。README内の`tree/master/...`リンクも`tree/main/...`に修正(`master`が凍結される以上、そのままだと古いコピーを指し続けてしまうため)。
- **さらに、release.ymlのpost-merge `Build`→`Commit built dist/`ステップも削除。** changesets/actionの`version`コマンド(`changeset:version` = `changeset version && npm run build`)がリリースPR作成時に既に`dist/`を再ビルドしてPRのコミットに含めているため、リリースPRを普通にマージするだけで(PR経由なのでブランチ保護と衝突しない)fresh distが`main`に乗る。この削除により、リリースジョブは`main`ブランチ自体には(タグ以外)一切pushしなくなるため、ブランチ保護のbypass設定が丸ごと不要になった。

## このPRの後に必要な手動対応(GitHub側の設定変更のため、このセッションのツールでは実行不可)
1. `next`ブランチを`main`にリネーム(GitHubのブランチリネーム機能を使うと、デフォルトブランチ設定・オープン中PRのbase・ブランチ保護ルールの多くが自動的に引き継がれる)。`master`は削除せずそのまま残してよい。

## Test plan
- [ ] このPRをマージ後、上記の手動対応(next→mainリネーム)を実施
- [ ] 次のchangeset付きPRをmainにマージし、release.ymlが正常にリリースPR作成→マージ→タグ作成まで通ることを確認(distの再ビルドがリリースPR側のコミットに含まれていることも確認)
- [ ] `master`が凍結されたままであること、`@master`向けの非推奨案内が意図通りであることを確認